### PR TITLE
Fix React rendering for React 18

### DIFF
--- a/app.js
+++ b/app.js
@@ -601,4 +601,8 @@ function App() {
   );
 }
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(<App />);
+}


### PR DESCRIPTION
## Summary
- replace deprecated `ReactDOM.render` with `createRoot` for React 18 compatibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab273e1c68832abc3fc477e4721a98