### PR TITLE
fix: enable react preset for runtime babel

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,6 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.21.2/babel.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-  <script src="app.js" type="text/babel"></script>
+  <script src="app.js" type="text/babel" data-presets="env,react"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure Babel transpiles JSX by adding `env,react` presets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab2b4dab80832a8bb94529610edf05